### PR TITLE
Allow overriding pgbouncer-secrets if it already exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 
 # rspec failure tracking
 .rspec_status
+
+# don't commit app-specific config
+.seira.yml

--- a/lib/seira/secrets.rb
+++ b/lib/seira/secrets.rb
@@ -114,7 +114,7 @@ module Seira
     def run_create_pgbouncer_secret
       db_user = args[0]
       db_password = args[1]
-      puts `kubectl create secret generic #{PGBOUNCER_SECRETS_NAME} --namespace #{app} --from-literal=DB_USER=#{db_user} --from-literal=DB_PASSWORD=#{db_password}`
+      write_secrets(secrets: { DB_USER: db_user, DB_PASSWORD: db_password }, secret_name: PGBOUNCER_SECRETS_NAME)
     end
 
     # In the normal case the secret we are updating is just main_secret_name,


### PR DESCRIPTION
If you create a new db and want to promote it to primary, there's no way to do that currently without knowing about the internals of how pgbouncer secrets are set up; this allows updating that config at the same abstraction level you have when creating it