### PR TITLE
Actually fix secrets

### DIFF
--- a/lib/seira/secrets.rb
+++ b/lib/seira/secrets.rb
@@ -85,7 +85,7 @@ module Seira
 
     def run_set
       secrets = fetch_current_secrets
-      secrets['data'].merge!(key_value_map.transform_values { |value| Base64.encode64(value).chomp })
+      secrets['data'].merge!(key_value_map.transform_values { |value| Base64.encode64(value).delete("\n") })
       write_secrets(secrets: secrets)
     end
 

--- a/lib/seira/secrets.rb
+++ b/lib/seira/secrets.rb
@@ -85,7 +85,7 @@ module Seira
 
     def run_set
       secrets = fetch_current_secrets
-      secrets['data'].merge!(key_value_map.transform_values { |value| Base64.encode64(value).delete("\n") })
+      secrets['data'].merge!(key_value_map.transform_values { |value| Base64.strict_encode64(value) })
       write_secrets(secrets: secrets)
     end
 

--- a/spec/secrets_spec.rb
+++ b/spec/secrets_spec.rb
@@ -32,7 +32,7 @@ describe Seira::Secrets do
       new_secrets: {
         'kind' => 'Secret',
         'data' => {
-          'FOO' => Base64.encode64('blah').chomp
+          'FOO' => Base64.encode64('blah').delete("\n")
         }
       }
     )
@@ -43,7 +43,7 @@ describe Seira::Secrets do
       old_secrets: {
         'kind' => 'Secret',
         'data' => {
-          'FOO' => Base64.encode64('old_value').chomp
+          'FOO' => Base64.encode64('old_value').delete("\n")
         }
       },
       action: 'set',
@@ -51,7 +51,7 @@ describe Seira::Secrets do
       new_secrets: {
         'kind' => 'Secret',
         'data' => {
-          'FOO' => Base64.encode64('new_value').chomp
+          'FOO' => Base64.encode64('new_value').delete("\n")
         }
       }
     )
@@ -62,7 +62,7 @@ describe Seira::Secrets do
       old_secrets: {
         'kind' => 'Secret',
         'data' => {
-          'OTHER_KEY' => Base64.encode64('other_value').chomp
+          'OTHER_KEY' => Base64.encode64('other_value').delete("\n")
         }
       },
       action: 'set',
@@ -70,8 +70,8 @@ describe Seira::Secrets do
       new_secrets: {
         'kind' => 'Secret',
         'data' => {
-          'OTHER_KEY' => Base64.encode64('other_value').chomp,
-          'FOO' => Base64.encode64('blah').chomp
+          'OTHER_KEY' => Base64.encode64('other_value').delete("\n"),
+          'FOO' => Base64.encode64('blah').delete("\n")
         }
       }
     )
@@ -88,8 +88,8 @@ describe Seira::Secrets do
       new_secrets: {
         'kind' => 'Secret',
         'data' => {
-          'FOO' => Base64.encode64('blah').chomp,
-          'BAR' => Base64.encode64('asdf').chomp
+          'FOO' => Base64.encode64('blah').delete("\n"),
+          'BAR' => Base64.encode64('asdf').delete("\n")
         }
       }
     )

--- a/spec/secrets_spec.rb
+++ b/spec/secrets_spec.rb
@@ -32,7 +32,7 @@ describe Seira::Secrets do
       new_secrets: {
         'kind' => 'Secret',
         'data' => {
-          'FOO' => Base64.encode64('blah').delete("\n")
+          'FOO' => Base64.strict_encode64('blah')
         }
       }
     )
@@ -43,7 +43,7 @@ describe Seira::Secrets do
       old_secrets: {
         'kind' => 'Secret',
         'data' => {
-          'FOO' => Base64.encode64('old_value').delete("\n")
+          'FOO' => Base64.strict_encode64('old_value')
         }
       },
       action: 'set',
@@ -51,7 +51,7 @@ describe Seira::Secrets do
       new_secrets: {
         'kind' => 'Secret',
         'data' => {
-          'FOO' => Base64.encode64('new_value').delete("\n")
+          'FOO' => Base64.strict_encode64('new_value')
         }
       }
     )
@@ -62,7 +62,7 @@ describe Seira::Secrets do
       old_secrets: {
         'kind' => 'Secret',
         'data' => {
-          'OTHER_KEY' => Base64.encode64('other_value').delete("\n")
+          'OTHER_KEY' => Base64.strict_encode64('other_value')
         }
       },
       action: 'set',
@@ -70,8 +70,8 @@ describe Seira::Secrets do
       new_secrets: {
         'kind' => 'Secret',
         'data' => {
-          'OTHER_KEY' => Base64.encode64('other_value').delete("\n"),
-          'FOO' => Base64.encode64('blah').delete("\n")
+          'OTHER_KEY' => Base64.strict_encode64('other_value'),
+          'FOO' => Base64.strict_encode64('blah')
         }
       }
     )
@@ -88,8 +88,8 @@ describe Seira::Secrets do
       new_secrets: {
         'kind' => 'Secret',
         'data' => {
-          'FOO' => Base64.encode64('blah').delete("\n"),
-          'BAR' => Base64.encode64('asdf').delete("\n")
+          'FOO' => Base64.strict_encode64('blah'),
+          'BAR' => Base64.strict_encode64('asdf')
         }
       }
     )


### PR DESCRIPTION
Apparently the issue wasn't just newlines at the end of the string; ruby's Base64 library puts newlines in the middle as well, which kubernetes is not happy with