### PR TITLE
do not remove superuser from proxyuser

### DIFF
--- a/lib/seira/db.rb
+++ b/lib/seira/db.rb
@@ -107,8 +107,6 @@ module Seira
         expect "Password for user postgres:"
         send "#{root_password}\\r"
         expect "postgres=>"
-        send "REVOKE cloudsqlsuperuser FROM proxyuser;\\r"
-        expect "postgres=>"
         send "ALTER ROLE proxyuser NOCREATEDB NOCREATEROLE;\\r"
         expect "postgres=>"
       BASH


### PR DESCRIPTION
Fixes https://app.clubhouse.io/handshake/story/31633/migrating-fails-if-requires-superuser. By removing superuser we removed the ability to run `rails db:migrate` and create extensions.