### PR TITLE
Jobs cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,11 @@ seira:
       cluster: gke_org-production_us-central1-a_production
       aliases:
         - "p"
-  valid_apps:
-    - app1
-    - app2
+  applications:
+    - name: app1
+      golden_tier: "web"
+    - name: app2
+      golden_tier: "web"
 ```
 
 This specification is read in and used to determine what `gcloud` context to use and what `kubectl` cluster to use when operating commands. For example, `seira internal` will connect to `org-internal` gcloud configuration and `gke_org-internal_us-central1-a_internal` kubectl cluster. For shorthand, `seira i` shorthand is specified as an alias.

--- a/lib/seira.rb
+++ b/lib/seira.rb
@@ -107,6 +107,7 @@ module Seira
       {
         cluster: cluster,
         project: project,
+        settings: settings,
         default_zone: settings.default_zone
       }
     end

--- a/lib/seira.rb
+++ b/lib/seira.rb
@@ -122,7 +122,7 @@ module Seira
     def perform_action_validation(klass:, action:)
       return true if simple_cluster_change?
 
-      unless klass == Seira::Cluster || settings.valid_apps.include?(app)
+      unless klass == Seira::Cluster || settings.applications.include?(app)
         puts "Invalid app name specified"
         exit(1)
       end

--- a/lib/seira.rb
+++ b/lib/seira.rb
@@ -8,6 +8,7 @@ require 'seira/app'
 require 'seira/cluster'
 require 'seira/memcached'
 require 'seira/pods'
+require 'seira/jobs'
 require 'seira/proxy'
 require 'seira/random'
 require 'seira/db'
@@ -23,6 +24,7 @@ module Seira
     CATEGORIES = {
       'secrets' => Seira::Secrets,
       'pods' => Seira::Pods,
+      'jobs' => Seira::Jobs,
       'db' => Seira::Db,
       'redis' => Seira::Redis,
       'memcached' => Seira::Memcached,

--- a/lib/seira/app.rb
+++ b/lib/seira/app.rb
@@ -165,6 +165,9 @@ module Seira
       Dir.foreach(destination) do |item|
         next if item == '.' || item == '..'
 
+        # Run manifests are not somethign that are deployed, but rather used to run one-off commands.
+        next if item == 'run.yaml' || item == 'run.yml'
+
         text = File.read("#{destination}/#{item}")
 
         new_contents = text

--- a/lib/seira/app.rb
+++ b/lib/seira/app.rb
@@ -175,7 +175,7 @@ module Seira
         next if item == '.' || item == '..'
 
         # If we have run into a directory item, skip it
-        next File.directory?("#{destination}/#{item}")
+        next if File.directory?("#{destination}/#{item}")
 
         # Skip any manifest file that has "seira-skip.yaml" at the end. Common use case is for Job definitions
         # to be used in "seira staging <app> jobs run"

--- a/lib/seira/app.rb
+++ b/lib/seira/app.rb
@@ -49,9 +49,9 @@ module Seira
       run_apply(restart: true)
     end
 
-    # TODO: Try a different tier if web DNE in that particular app.
     def ask_cluster_for_current_revision
-      current_image = `kubectl get deployment --namespace=#{app} -l app=#{app},tier=web -o=jsonpath='{$.items[:1].spec.template.spec.containers[:1].image}'`.strip.chomp
+      tier = context[:settings].config_for_app(app)['golden_tier'] || 'web'
+      current_image = `kubectl get deployment --namespace=#{app} -l app=#{app},tier=#{tier} -o=jsonpath='{$.items[:1].spec.template.spec.containers[:1].image}'`.strip.chomp
       current_revision = current_image.split(':').last
       current_revision
     end

--- a/lib/seira/jobs.rb
+++ b/lib/seira/jobs.rb
@@ -119,7 +119,6 @@ module Seira
         job_spec = nil
         loop do
           job_spec = JSON.parse(`kubectl --namespace=#{app} get job #{unique_name} -o json`)
-          puts job_spec['status']['succeeded']
           break if !job_spec['status']['succeeded'].nil? || !job_spec['status']['failed'].nil?
           print '.'
           sleep 3

--- a/lib/seira/jobs.rb
+++ b/lib/seira/jobs.rb
@@ -1,0 +1,158 @@
+require 'json'
+
+module Seira
+  class Jobs
+    VALID_ACTIONS = %w[help list delete logs run].freeze
+    SUMMARY = "Manage your application's jobs.".freeze
+
+    attr_reader :app, :action, :args, :job_name, :context
+
+    def initialize(app:, action:, args:, context:)
+      @app = app
+      @action = action
+      @context = context
+      @args = args
+      @job_name = args[0]
+    end
+
+    def run
+      case action
+      when 'help'
+        run_help
+      when 'list'
+        run_list
+      when 'delete'
+        run_delete
+      when 'logs'
+        run_logs
+      when 'run'
+        run_run
+      else
+        fail "Unknown command encountered"
+      end
+    end
+
+    private
+
+    def run_help
+      puts SUMMARY
+      puts "\n\n"
+      puts "TODO"
+    end
+
+    def run_list
+      puts `kubectl get jobs --namespace=#{app} -o wide`
+    end
+
+    def run_delete
+      puts `kubectl delete job #{job_name} --namespace=#{app}`
+    end
+
+    def run_logs
+      puts `kubectl logs #{job_name} --namespace=#{app} -c #{app}`
+    end
+
+    def run_run
+      # Set defaults
+      tier = 'web'
+      clear_commands = false
+      detached = false
+      container_name = app
+
+      # Loop through args and process any that aren't just the command to run
+      loop do
+        arg = args.first
+        if arg.nil?
+          puts 'Please specify a command to run'
+          exit(1)
+        end
+        break unless arg.start_with? '--'
+        if arg.start_with? '--tier='
+          tier = arg.split('=')[1]
+        elsif arg == '--clear-commands'
+          clear_commands = true
+        elsif arg == '--detached'
+          detached = true
+        elsif arg.start_with? '--container='
+          container_name = arg.split('=')[1]
+        else
+          puts "Warning: Unrecognized argument #{arg}"
+        end
+        args.shift
+      end
+
+      # Any remaining args are the command to run
+      command = args.join(' ')
+
+      # Find a 'template' pod from the proper tier
+      template_pod = fetch_pods(app: app, tier: tier).first
+      if template_pod.nil?
+        puts "Unable to find #{tier} tier pod to copy config from"
+        exit(1)
+      end
+
+      # Use that template pod's configuration to create a new temporary pod
+      temp_name = "#{app}-temp-#{Random.unique_name}"
+      spec = template_pod['spec']
+      temp_pod = {
+        apiVersion: template_pod['apiVersion'],
+        kind: 'Job',
+        spec: spec,
+        metadata: {
+          name: temp_name
+        }
+      }
+      spec['restartPolicy'] = 'Never'
+      if clear_commands
+        spec['containers'].each do |container|
+          container['command'] = ['bash', '-c', 'tail -f /dev/null']
+        end
+      end
+
+      if detached
+        target_container = spec['containers'].find { |container| container['name'] == container_name }
+        if target_container.nil?
+          puts "Could not find container '#{container_name}' to run command in"
+          exit(1)
+        end
+        target_container['command'] = ['bash', '-c', command]
+      end
+
+      puts "Creating temporary pod #{temp_name}"
+      unless system("kubectl --namespace=#{app} create -f - <<JSON\n#{temp_pod.to_json}\nJSON")
+        puts 'Failed to create pod'
+        exit(1)
+      end
+
+      unless detached
+        # Check pod status until it's ready to connect to
+        print 'Waiting for pod to start...'
+        loop do
+          pod = JSON.parse(`kubectl --namespace=#{app} get pods/#{temp_name} -o json`)
+          break if pod['status']['phase'] == 'Running'
+          print '.'
+          sleep 1
+        end
+        print "\n"
+
+        # Connect to the pod, running the specified command
+        connect_to_pod(temp_name, command)
+
+        # Clean up
+        unless system("kubectl --namespace=#{app} delete pod #{temp_name}")
+          puts "Warning: failed to clean up pod #{temp_name}"
+        end
+      end
+    end
+
+    def fetch_pods(filters)
+      filter_string = filters.map { |k, v| "#{k}=#{v}" }.join(',')
+      JSON.parse(`kubectl get pods --namespace=#{app} -o json --selector=#{filter_string}`)['items']
+    end
+
+    def connect_to_pod(name, command = 'bash')
+      puts "Connecting to #{name}..."
+      system("kubectl exec -ti #{name} --namespace=#{app} -- #{command}")
+    end
+  end
+end

--- a/lib/seira/jobs.rb
+++ b/lib/seira/jobs.rb
@@ -96,10 +96,10 @@ module Seira
       source = "kubernetes/#{context[:cluster]}/#{app}" # TODO: Move to method in app.rb
       Dir.mktmpdir do |destination|
         revision = ENV['REVISION']
-        file_name = "run.skip.yaml"
+        file_name = "template.yaml"
 
         FileUtils.mkdir_p destination # Create the nested directory
-        FileUtils.copy_file "#{source}/#{file_name}", "#{destination}/#{file_name}"
+        FileUtils.copy_file "#{source}/jobs/#{file_name}", "#{destination}/#{file_name}"
 
         # TOOD: Move this into a method since it is copied from app.rb
         text = File.read("#{destination}/#{file_name}")

--- a/lib/seira/jobs.rb
+++ b/lib/seira/jobs.rb
@@ -48,7 +48,7 @@ module Seira
 
     def run_run
       gcp_app = App.new(app: app, action: 'apply', args: [""], context: context)
-      
+
       # Set defaults
       detached = false # Wait for job to finish before continuing.
       no_delete = false # Delete at end
@@ -112,9 +112,6 @@ module Seira
         puts "Running 'kubectl apply -f #{destination}'"
         system("kubectl apply -f #{destination}")
       end
-
-      # TODO: See https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/ for deleting old pods. As long as
-      # we are logging to papertrail or somewhere, we can delete the job when it is done.
 
       unless detached
         # Check job status until it's finished

--- a/lib/seira/jobs.rb
+++ b/lib/seira/jobs.rb
@@ -2,7 +2,7 @@ require 'json'
 
 module Seira
   class Jobs
-    VALID_ACTIONS = %w[help list delete logs run].freeze
+    VALID_ACTIONS = %w[help list delete run].freeze
     SUMMARY = "Manage your application's jobs.".freeze
 
     attr_reader :app, :action, :args, :job_name, :context
@@ -23,8 +23,6 @@ module Seira
         run_list
       when 'delete'
         run_delete
-      when 'logs'
-        run_logs
       when 'run'
         run_run
       else
@@ -46,10 +44,6 @@ module Seira
 
     def run_delete
       puts `kubectl delete job #{job_name} --namespace=#{app}`
-    end
-
-    def run_logs
-      puts `kubectl logs #{job_name} --namespace=#{app} -c #{app}`
     end
 
     def run_run
@@ -139,16 +133,6 @@ module Seira
           system("kubectl delete job #{unique_name} -n #{app}")
         end
       end
-    end
-
-    def fetch_pods(filters)
-      filter_string = filters.map { |k, v| "#{k}=#{v}" }.join(',')
-      JSON.parse(`kubectl get pods --namespace=#{app} -o json --selector=#{filter_string}`)['items']
-    end
-
-    def connect_to_pod(name, command = 'bash')
-      puts "Connecting to #{name}..."
-      system("kubectl exec -ti #{name} --namespace=#{app} -- #{command}")
     end
   end
 end

--- a/lib/seira/jobs.rb
+++ b/lib/seira/jobs.rb
@@ -50,7 +50,7 @@ module Seira
       gcp_app = App.new(app: app, action: 'apply', args: [""], context: context)
 
       # Set defaults
-      detached = false # Wait for job to finish before continuing.
+      async = false # Wait for job to finish before continuing.
       no_delete = false # Delete at end
 
       # Loop through args and process any that aren't just the command to run
@@ -63,8 +63,8 @@ module Seira
 
         break unless arg.start_with? '--'
 
-        if arg == '--detached'
-          detached = true
+        if arg == '--async'
+          async = true
         elsif arg == '--no-delete'
           no_delete = true
         else
@@ -74,8 +74,8 @@ module Seira
         args.shift
       end
 
-      if detached && !no_delete
-        puts "Cannot delete Job after running if Job is detached, since we don't know when it finishes."
+      if async && !no_delete
+        puts "Cannot delete Job after running if Job is async, since we don't know when it finishes."
         exit(1)
       end
 
@@ -113,7 +113,7 @@ module Seira
         system("kubectl apply -f #{destination}")
       end
 
-      unless detached
+      unless async
         # Check job status until it's finished
         print 'Waiting for job to complete...'
         job_spec = nil

--- a/lib/seira/settings.rb
+++ b/lib/seira/settings.rb
@@ -24,12 +24,12 @@ module Seira
       settings['seira']['default_zone']
     end
 
-    def valid_apps
-      settings['seira']['valid_apps'].map { |app| app['name'] }
+    def applications
+      settings['seira']['applications'].map { |app| app['name'] }
     end
 
     def config_for_app(app_name)
-      settings['seira']['valid_apps'].find { |app| app['name'] == app_name }
+      settings['seira']['applications'].find { |app| app['name'] == app_name }
     end
 
     def valid_cluster_names

--- a/lib/seira/settings.rb
+++ b/lib/seira/settings.rb
@@ -25,7 +25,11 @@ module Seira
     end
 
     def valid_apps
-      settings['seira']['valid_apps']
+      settings['seira']['valid_apps'].map { |app| app['name'] }
+    end
+
+    def config_for_app(app_name)
+      settings['seira']['valid_apps'].find { |app| app['name'] == app_name }
     end
 
     def valid_cluster_names


### PR DESCRIPTION
This prototypes using Job via a configurable manifest file that the user can specify.

Example run:
```
: seira s handshake jobs run rails secret
Activated [staging].
Switched to context "gke_handshake-staging_us-central1-c_staging".
Running 'kubectl apply -f /var/folders/z7/hq6y09g14fv3_93nh6k3_q5m0000gn/T/d20180124-61929-13t866z'
job "handshake-run-white-javanese" created
Waiting for job to complete...........Job finished. Deleting Job from cluster for cleanup.job "handshake-run-white-javanese" deleted
:
```

https://github.com/joinhandshake/ops/pull/97

Can specify --detached or --no-delete as well. The output shows up in papertrail, which means that deleting after its done is acceptable.

Advantages:

- Can configure the REVISION. For example, could run a job on a NEW revision before deploying that revision.
- Can configure the Cpu and memory. Because we were before copying web template, and web template has very large cpu and memory claims, it would have trouble finding a node to run on. This makes it less likely to have that issue.
- In the future we can get fancy with things like `--size=large`, `--size=x-large` on cpu and memory configurations
- The manifest used for the Job is configurable just like any other manifest. For example, we don't need to open a port nor do we want liveness or readiness probes on one-off jobs.
- Because we are using the Job object in K8s, we can get features such as parallelism and configurable restart or backoff policies.

Because it's a simple manifest, we can configure further in the future if we'd like. 

This PR also introduces the concept of "skip.yaml". Any manifest that ends with that will not be applied when deploying.

Ideas for finishing this:

- Add a configuration option in seira.yml for "run_file_name" rather than hardcoding "run.skip.yaml"
- Not now, but in future, a considerable refactor to fix the various TODO I have in here.