### PR TITLE
Monitor rollouts after apply

### DIFF
--- a/lib/seira/version.rb
+++ b/lib/seira/version.rb
@@ -1,3 +1,3 @@
 module Seira
-  VERSION = "0.2.0".freeze
+  VERSION = "0.2.1".freeze
 end


### PR DESCRIPTION
Pretty quick-and-dirty but it works

Running `app restart` is an easy way to see what the output will look like