### PR TITLE
Refactor pods connect/run

### DIFF
--- a/lib/seira/version.rb
+++ b/lib/seira/version.rb
@@ -1,3 +1,3 @@
 module Seira
-  VERSION = "0.3.8".freeze
+  VERSION = "0.4.0".freeze
 end


### PR DESCRIPTION
This assumes that each app has a `terminal` deployment which is set up for the purpose of exec-ing into.

Rather than having two separate `pods run` and `pods connect` commands, this just has `pods connect` and allows specifying a `--dedicated` flag which operates similarly to how `pods run` did. Both these methods have their merits (e.g. non-dedicated connects super quickly; dedicated doesn't get kicked out due to deploys), but non-dedicated is a more reliable default.

The functionality from `pods run --detached` has been replaced by `jobs run`.