### PR TITLE
Run job as shell command

### DIFF
--- a/lib/seira/jobs.rb
+++ b/lib/seira/jobs.rb
@@ -84,7 +84,7 @@ module Seira
       replacement_hash = {
         'UNIQUE_NAME' => unique_name,
         'REVISION' => revision,
-        'COMMAND' => command.split(' ').map { |part| "\"#{part}\"" }.join(", "),
+        'COMMAND' => %("sh", "-c", "#{command}"),
         'CPU_REQUEST' => '200m',
         'CPU_LIMIT' => '500m',
         'MEMORY_REQUEST' => '500Mi',


### PR DESCRIPTION
If you're trying set shell variables in a command like `LOG_LEVEL=debug rake some_task`, the `LOG_LEVEL=debug` part ends up being interpreted as the executable and crashes. Trying to route around this with `jobs run bash -c "LOG_LEVEL=debug rake some_task"` ends up being equivalent to running `bash -c LOG_LEVEL=debug`, due to the logic of splitting on spaces and passing every piece as a separate argument.

Treating the command as just a one-piece string and wrapping with `sh -c` allows using a more natural syntax to run commands like this.