### PR TITLE
Allow specifying config file location with ENV variable

### DIFF
--- a/lib/seira/settings.rb
+++ b/lib/seira/settings.rb
@@ -7,7 +7,7 @@ module Seira
 
     attr_reader :config_path
 
-    def initialize(config_path: DEFAULT_CONFIG_PATH)
+    def initialize(config_path: ENV["SEIRA_CONFIG_PATH"] || DEFAULT_CONFIG_PATH)
       @config_path = config_path
     end
 


### PR DESCRIPTION
Break the dependency of having to run seria from within the directory the config file is defined