### PR TITLE
warn users if running apply, and an ENV is not present

### DIFF
--- a/lib/seira/app.rb
+++ b/lib/seira/app.rb
@@ -80,6 +80,11 @@ module Seira
       revision = nil
       deployment = :all
 
+      warn_env = context[:settings].warn_if_env_not_present_for_apply
+        if warn_env && ENV[warn_env].nil?
+          exit(1) unless HighLine.agree("WARNING: The Environment Variable '#{warn_env}' is not present. Are you sure you want to continue? This command will apply your local Kubernetes configs. If you continue, make sure you have the latest master changes and valid local YAML.")
+        end
+
       args.each do |arg|
         if arg == '--async'
           async = true

--- a/lib/seira/app.rb
+++ b/lib/seira/app.rb
@@ -80,10 +80,10 @@ module Seira
       revision = nil
       deployment = :all
 
-      warn_env = context[:settings].warn_if_env_not_present_for_apply
-        if warn_env && ENV[warn_env].nil?
-          exit(1) unless HighLine.agree("WARNING: The Environment Variable '#{warn_env}' is not present. Are you sure you want to continue? This command will apply your local Kubernetes configs. If you continue, make sure you have the latest master changes and valid local YAML.")
-        end
+      warn_env = context[:settings].expected_environment_variable_during_deploys
+      if warn_env && ENV[warn_env].nil?
+        exit(1) unless HighLine.agree("WARNING: Expected '#{warn_env}' to be present, but is not. This might mean your are running a deploy in an environment that is not safe. Are you sure you want to continue? This command will apply your *local* kubernetes configs. If you continue, make sure you have the latest master changes and valid local YAML.")
+      end
 
       args.each do |arg|
         if arg == '--async'

--- a/lib/seira/settings.rb
+++ b/lib/seira/settings.rb
@@ -60,6 +60,10 @@ module Seira
       settings['seira']['clusters'][cluster]['project']
     end
 
+    def warn_if_env_not_present_for_apply
+      settings['seira']['warn_if_env_not_present_for_apply']
+    end
+
     private
 
     def parse_settings

--- a/lib/seira/settings.rb
+++ b/lib/seira/settings.rb
@@ -60,8 +60,8 @@ module Seira
       settings['seira']['clusters'][cluster]['project']
     end
 
-    def warn_if_env_not_present_for_apply
-      settings['seira']['warn_if_env_not_present_for_apply']
+    def expected_environment_variable_during_deploys
+      settings['seira']['expected_environment_variable_during_deploys']
     end
 
     private


### PR DESCRIPTION
This could help protect against accidental local deploys