### PR TITLE
fix(pods): Add error for no pods available

### DIFF
--- a/lib/seira/pods.rb
+++ b/lib/seira/pods.rb
@@ -95,10 +95,12 @@ module Seira
                      existing_pod
                    elsif dedicated || pod_name.to_s.empty?
                      Helpers.fetch_pods(context: context, filters: { tier: tier || 'terminal' }).sample
-                   else
-                     puts 'Could not find pod to connect to'
-                     exit(1)
                    end
+
+      if target_pod.nil?
+        puts 'Could not find pod to connect to'
+        exit(1)
+      end
 
       if dedicated
         new_pod = if pod_name.nil?

--- a/spec/pods_spec.rb
+++ b/spec/pods_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe Seira::Pods do
+  it 'exists with error when no pods can be fetched' do
+    pods = Seira::Pods.new(app: 'spec', action: 'connect', args: [], context: '')
+
+    expect(Seira::Helpers).to receive(:fetch_pods).and_return([])
+
+    expect do
+      expect { pods.run }.to raise_exception(SystemExit)
+    end.to output("Could not find pod to connect to\n").to_stdout
+  end
+end


### PR DESCRIPTION
Siera returns fails with a Ruby exception:
* Attempting to connect to a pod in an existing application, and
* Not creating a dedicated pod, and
* No pods are currently running in the specified tier (or 'terminal', if none specified).

This change handles this condition in the same way other, related failures are handled. An error message is printed, and Siera exits with status code 1.