### PR TITLE
bootstrap no cloudsql

### DIFF
--- a/lib/seira/app.rb
+++ b/lib/seira/app.rb
@@ -68,8 +68,6 @@ module Seira
       # Create namespace before anything else
       kubectl("apply -f kubernetes/#{context[:cluster]}/#{app}/00-namespace.yaml", context: context)
       bootstrap_main_secret
-      bootstrap_cloudsql_secret
-      bootstrap_gcr_secret
 
       puts "Successfully installed"
     end
@@ -182,20 +180,6 @@ module Seira
       rails_env = Helpers.rails_env(context: context)
 
       kubectl("create secret generic #{main_secret_name} --from-literal=RAILS_ENV=#{rails_env} --from-literal=RACK_ENV=#{rails_env}", context: context)
-    end
-
-    # We use a secret in our container to use a service account to connect to our cloudsql databases. The secret in 'default'
-    # namespace can't be used in this namespace, so copy it over to our namespace.
-    def bootstrap_gcr_secret
-      secrets = Seira::Secrets.new(app: app, action: action, args: args, context: context)
-      secrets.copy_secret_across_namespace(key: 'gcr-secret', from: 'default', to: app)
-    end
-
-    # We use a secret in our container to use a service account to connect to our docker registry. The secret in 'default'
-    # namespace can't be used in this namespace, so copy it over to our namespace.
-    def bootstrap_cloudsql_secret
-      secrets = Seira::Secrets.new(app: app, action: action, args: args, context: context)
-      secrets.copy_secret_across_namespace(key: 'cloudsql-credentials', from: 'default', to: app)
     end
 
     def find_and_replace_revision(source:, destination:, replacement_hash:)

--- a/lib/seira/cluster.rb
+++ b/lib/seira/cluster.rb
@@ -70,20 +70,13 @@ module Seira
     # new apps are built.
     def run_bootstrap
       dockercfg_location = args[0]
-      cloudsql_credentials_location = args[1]
 
       if dockercfg_location.nil? || dockercfg_location == ''
         puts 'Please specify the dockercfg json key location as first param.'
         exit(1)
       end
 
-      if cloudsql_credentials_location.nil? || cloudsql_credentials_location == ''
-        puts 'Please specify the cloudsql_credentials_location json key location as second param.'
-        exit(1)
-      end
-
       puts `kubectl create secret docker-registry gcr-secret --docker-username=_json_key --docker-password="$(cat #{dockercfg_location})" --docker-server=https://gcr.io --docker-email=doesnotmatter@example.com`
-      puts `kubectl create secret generic cloudsql-credentials --namespace default --from-file=credentials.json=#{cloudsql_credentials_location}`
     end
 
     def run_upgrade_master

--- a/lib/seira/cluster.rb
+++ b/lib/seira/cluster.rb
@@ -7,7 +7,7 @@ module Seira
   class Cluster
     include Seira::Commands
 
-    VALID_ACTIONS = %w[help bootstrap upgrade-master].freeze
+    VALID_ACTIONS = %w[help upgrade-master].freeze
     SUMMARY = "For managing whole clusters.".freeze
 
     attr_reader :action, :args, :context, :settings
@@ -23,8 +23,6 @@ module Seira
       case action
       when 'help'
         run_help
-      when 'bootstrap'
-        run_bootstrap
       when 'upgrade-master'
         run_upgrade_master
       else
@@ -64,20 +62,6 @@ module Seira
     end
 
     private
-
-    # Intended for use when spinning up a whole new cluster. It stores two main secrets
-    # in the default space that are intended to be copied into individual namespaces when
-    # new apps are built.
-    def run_bootstrap
-      dockercfg_location = args[0]
-
-      if dockercfg_location.nil? || dockercfg_location == ''
-        puts 'Please specify the dockercfg json key location as first param.'
-        exit(1)
-      end
-
-      puts `kubectl create secret docker-registry gcr-secret --docker-username=_json_key --docker-password="$(cat #{dockercfg_location})" --docker-server=https://gcr.io --docker-email=doesnotmatter@example.com`
-    end
 
     def run_upgrade_master
       cluster = context[:cluster]

--- a/lib/seira/version.rb
+++ b/lib/seira/version.rb
@@ -1,3 +1,3 @@
 module Seira
-  VERSION = "0.5.0".freeze
+  VERSION = "0.5.1".freeze
 end


### PR DESCRIPTION
we no longer need to bootstrap clusters because we don't use `gcr-secret` or `cloudsql-credentials`

for apps, we only need to bootstrap the main secret