### PR TITLE
update db creation script

### DIFF
--- a/lib/seira/db/alter_proxyuser_roles.rb
+++ b/lib/seira/db/alter_proxyuser_roles.rb
@@ -1,0 +1,42 @@
+module Seira
+  class Db
+    class AlterProxyuserRoles
+      include Seira::Commands
+
+      attr_reader :name, :root_password
+
+      def initialize(app:, action:, args:, context:)
+        if args.length != 2
+          puts 'Specify db name and root password as the positional arguments'
+          exit(1)
+        end
+
+        @name = args[0]
+        @root_password = args[1]
+      end
+
+      def run
+        # Connect to the instance and remove some of the default group memberships and permissions
+        # from proxyuser, leaving it with only what it needs to be able to do
+        expect_script = <<~BASH
+          set timeout 90
+          spawn gcloud sql connect #{name}
+          expect "Password for user postgres:"
+          send "#{root_password}\\r"
+          expect "postgres=>"
+          send "ALTER ROLE proxyuser NOCREATEDB NOCREATEROLE;\\r"
+          expect "postgres=>"
+        BASH
+        if system("expect <<EOF\n#{expect_script}EOF")
+          puts "Successfully removed unnecessary permissions from proxyuser"
+        else
+          puts "Failed to remove unnecessary permissions from proxyuser."
+          puts "You may need to whitelist the correct IP in the gcloud UI."
+          puts "You can get the correct IP from https://www.whatismyip.com/"
+          puts "Make sure to remove it from the whitelist afterward."
+          exit(1)
+        end
+      end
+    end
+  end
+end

--- a/lib/seira/db/alter_proxyuser_roles.rb
+++ b/lib/seira/db/alter_proxyuser_roles.rb
@@ -33,7 +33,7 @@ module Seira
           puts "Failed to remove unnecessary permissions from proxyuser."
           puts "You may need to whitelist the correct IP in the gcloud UI."
           puts "You can get the correct IP from https://www.whatismyip.com/"
-          puts "Make sure to remove it from the whitelist afterward."
+          puts "Make sure to remove it from the whitelist after successfully running db alter-proxyuser-roles"
           exit(1)
         end
       end

--- a/lib/seira/db/create.rb
+++ b/lib/seira/db/create.rb
@@ -341,9 +341,9 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-  - protocol: TCP
-    port: 6432
-    targetPort: 6432
+    - protocol: TCP
+      port: 6432
+      targetPort: 6432
   selector:
     app: #{app}
     tier: #{pgbouncer_tier}

--- a/lib/seira/db/create.rb
+++ b/lib/seira/db/create.rb
@@ -246,7 +246,7 @@ module Seira
         # TODO: Clean this up by moving into a proper templated yaml file
         pgbouncer_yaml = <<-FOO
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: #{name}-pgbouncer

--- a/lib/seira/db/create.rb
+++ b/lib/seira/db/create.rb
@@ -325,6 +325,10 @@ spec:
             requests:
               cpu: 100m
               memory: 300Mi
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "killall -INT pgbouncer && sleep 20"]
 ---
 apiVersion: v1
 kind: Service

--- a/lib/seira/db/create.rb
+++ b/lib/seira/db/create.rb
@@ -212,6 +212,11 @@ metadata:
     database: #{name}
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      app: #{app}
+      tier: #{pgbouncer_tier}
+      database: #{name}
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/lib/seira/version.rb
+++ b/lib/seira/version.rb
@@ -1,3 +1,3 @@
 module Seira
-  VERSION = "0.5.1".freeze
+  VERSION = "0.5.2".freeze
 end


### PR DESCRIPTION
The only workaround I could get working after spending way too long on this was to manually whitelist the correct IP in the gcloud UI after the initial attempt fails and then running the db create command with the `--alter-proxy-user-roles-only` flag

`seira demo2 student-backend db create --alter-proxy-user-roles-only`

https://joinhandshake.slack.com/archives/C2PJL2NHL/p1545262385133200?thread_ts=1545166325.122000&cid=C2PJL2NHL

Can't spend any more time on this now but at least the description can potentially unblock others in case they need to spin up new dbs before we get a better fix in place.