### PR TITLE
Don't check server version of kubectl on launch

### DIFF
--- a/lib/seira.rb
+++ b/lib/seira.rb
@@ -146,7 +146,7 @@ module Seira
 
     def base_validations
       # gcloud and kubectl is required, hard error if not installed
-      unless system("gcloud version -c > /dev/null 2>&1")
+      unless system("gcloud version > /dev/null 2>&1")
         puts "Gcloud library not installed properly. Please install `gcloud` before using seira.".red
         exit(1)
       end

--- a/lib/seira.rb
+++ b/lib/seira.rb
@@ -146,12 +146,12 @@ module Seira
 
     def base_validations
       # gcloud and kubectl is required, hard error if not installed
-      unless system("gcloud version > /dev/null 2>&1")
+      unless system("gcloud version -c > /dev/null 2>&1")
         puts "Gcloud library not installed properly. Please install `gcloud` before using seira.".red
         exit(1)
       end
 
-      unless system("kubectl version > /dev/null 2>&1")
+      unless system("kubectl version -c > /dev/null 2>&1")
         puts "Kubectl library not installed properly. Please install `kubectl` before using seira.".red
         exit(1)
       end


### PR DESCRIPTION
When `kubectl version` is run, it phones home to check what version exists on the server. At best, this creates some lag waiting for the HTTP call. At worst, the remote is unavailable (causing `kubectl version` to return a non-zero exit status), and `seira` incorrectly interprets that as `kubectl` not being installed properly.

This change adds the `-c` flag to that check, which suppresses the call to the remote server. This should speed up `seira` start time and prevent complete failure if the remote is unavailable.