### PR TITLE
Add Region to Node Pool Commands

### DIFF
--- a/lib/seira.rb
+++ b/lib/seira.rb
@@ -136,8 +136,8 @@ module Seira
         cluster: cluster,
         project: project,
         settings: settings,
-        region: cluster['region'],
-        zone: cluster['zone'],
+        region: settings.region_for_cluster(cluster),
+        zone: settings.zone_for_cluster(cluster),
         app: app,
         action: action,
         args: args

--- a/lib/seira/commands/gcloud.rb
+++ b/lib/seira/commands/gcloud.rb
@@ -32,7 +32,7 @@ module Seira
             end
 
           unless context.nil?
-            rv = "#{rv} --project=#{context[:project]}"
+            rv = "#{rv} --region=#{context[:region]} --project=#{context[:project]}"
           end
 
           rv

--- a/lib/seira/node_pools.rb
+++ b/lib/seira/node_pools.rb
@@ -58,7 +58,7 @@ module Seira
     # TODO: Info about what is running on it?
     # TODO: What information do we get in the json format we could include here?
     def run_list
-      gcloud("container node-pools list --cluster #{context[:cluster]} --region #{context[:region]}", context: context, format: :boolean)
+      gcloud("container node-pools list --cluster #{context[:cluster]}", context: context, format: :boolean)
     end
 
     def run_list_nodes
@@ -93,7 +93,6 @@ module Seira
       command =
         "container node-pools create #{new_pool_name} \
         --cluster=#{context[:cluster]} \
-        --region=#{context[:region]} \
         --disk-size=#{disk_size} \
         --image-type=#{image_type} \
         --machine-type=#{machine_type} \
@@ -158,7 +157,7 @@ module Seira
 
       exit(1) unless HighLine.agree "Node pool has successfully been cordoned and drained, and should be safe to delete. Continue deleting node pool #{node_pool_name}?"
 
-      if gcloud("container node-pools delete #{node_pool_name} --cluster #{context[:cluster]} --region #{context[:region]}", context: context, format: :boolean)
+      if gcloud("container node-pools delete #{node_pool_name} --cluster #{context[:cluster]}", context: context, format: :boolean)
         puts 'Node pool deleted successfully'
       else
         puts 'Failed to delete old pool'
@@ -168,7 +167,7 @@ module Seira
 
     # TODO: Represent by a ruby object?
     def node_pools
-      JSON.parse(gcloud("container node-pools list --cluster #{context[:cluster]} --region #{context[:region]}", context: context, format: :json))
+      JSON.parse(gcloud("container node-pools list --cluster #{context[:cluster]}", context: context, format: :json))
     end
 
     def nodes_for_pool(pool_name)

--- a/lib/seira/node_pools.rb
+++ b/lib/seira/node_pools.rb
@@ -58,7 +58,7 @@ module Seira
     # TODO: Info about what is running on it?
     # TODO: What information do we get in the json format we could include here?
     def run_list
-      gcloud("container node-pools list --cluster #{context[:cluster]}", context: context, format: :boolean)
+      gcloud("container node-pools list --cluster #{context[:cluster]} --region #{context[:region]}", context: context, format: :boolean)
     end
 
     def run_list_nodes
@@ -93,6 +93,7 @@ module Seira
       command =
         "container node-pools create #{new_pool_name} \
         --cluster=#{context[:cluster]} \
+        --region=#{context[:region]} \
         --disk-size=#{disk_size} \
         --image-type=#{image_type} \
         --machine-type=#{machine_type} \
@@ -157,7 +158,7 @@ module Seira
 
       exit(1) unless HighLine.agree "Node pool has successfully been cordoned and drained, and should be safe to delete. Continue deleting node pool #{node_pool_name}?"
 
-      if gcloud("container node-pools delete #{node_pool_name} --cluster #{context[:cluster]}", context: context, format: :boolean)
+      if gcloud("container node-pools delete #{node_pool_name} --cluster #{context[:cluster]} --region #{context[:region]}", context: context, format: :boolean)
         puts 'Node pool deleted successfully'
       else
         puts 'Failed to delete old pool'
@@ -167,7 +168,7 @@ module Seira
 
     # TODO: Represent by a ruby object?
     def node_pools
-      JSON.parse(gcloud("container node-pools list --cluster #{context[:cluster]}", context: context, format: :json))
+      JSON.parse(gcloud("container node-pools list --cluster #{context[:cluster]} --region #{context[:region]}", context: context, format: :json))
     end
 
     def nodes_for_pool(pool_name)

--- a/lib/seira/settings.rb
+++ b/lib/seira/settings.rb
@@ -56,6 +56,14 @@ module Seira
       settings['seira']['clusters'][cluster]['project']
     end
 
+    def region_for_cluster(cluster)
+      settings['seira']['clusters'][cluster]['region']
+    end
+
+    def zone_for_cluster(cluster)
+      settings['seira']['clusters'][cluster]['zone']
+    end
+
     def expected_environment_variable_during_deploys
       settings['seira']['expected_environment_variable_during_deploys']
     end

--- a/lib/seira/version.rb
+++ b/lib/seira/version.rb
@@ -1,3 +1,3 @@
 module Seira
-  VERSION = "0.5.3".freeze
+  VERSION = "0.5.4".freeze
 end


### PR DESCRIPTION
Apply `--region` to all commands to fix:
```
ERROR: (gcloud.container.node-pools.list) One of [--zone, --region] must be supplied: Please specify location.
```