### PR TITLE
Fix create_readonly_user

### DIFF
--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -45,6 +45,16 @@ module Seira
       rescue
         'unknown'
       end
+
+      def sql_ips(name, context:)
+        @_ips ||= begin
+          describe_command = "sql instances describe #{name}"
+          json = JSON.parse(Seira::Commands.gcloud(describe_command, context: context, format: :json))
+          private_ip = json['ipAddresses'].find { |address| address['type'] == 'PRIVATE' }['ipAddress']
+          public_ip = json['ipAddresses'].find { |address| address['type'] == 'PRIMARY' }['ipAddress']
+          { private: private_ip, public: public_ip }
+        end
+      end
     end
   end
 end

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -47,13 +47,11 @@ module Seira
       end
 
       def sql_ips(name, context:)
-        @_ips ||= begin
-          describe_command = "sql instances describe #{name}"
-          json = JSON.parse(Seira::Commands.gcloud(describe_command, context: context, format: :json))
-          private_ip = json['ipAddresses'].find { |address| address['type'] == 'PRIVATE' }['ipAddress']
-          public_ip = json['ipAddresses'].find { |address| address['type'] == 'PRIMARY' }['ipAddress']
-          { private: private_ip, public: public_ip }
-        end
+        describe_command = "sql instances describe #{name}"
+        json = JSON.parse(Seira::Commands.gcloud(describe_command, context: context, format: :json))
+        private_ip = json['ipAddresses'].find { |address| address['type'] == 'PRIVATE' }['ipAddress']
+        public_ip = json['ipAddresses'].find { |address| address['type'] == 'PRIMARY' }['ipAddress']
+        { private: private_ip, public: public_ip }
       end
     end
   end

--- a/lib/seira.rb
+++ b/lib/seira.rb
@@ -56,6 +56,8 @@ module Seira
       # arg is not in the ARGV array and should be skipped over
       if ARGV[0] == 'help'
         @category = reversed_args.pop
+      elsif ARGV[0] == 'version'
+        @category = reversed_args.pop
       elsif ARGV[1] == 'cluster'
         cluster = reversed_args.pop
         @category = reversed_args.pop
@@ -99,6 +101,9 @@ module Seira
     def run
       if category == 'help'
         run_base_help
+        exit(0)
+      elsif category == 'version'
+        puts "Seira version: #{Seira::VERSION}"
         exit(0)
       elsif category == 'setup'
         Seira::Setup.new(target: cluster, args: args, settings: settings).run

--- a/lib/seira/db.rb
+++ b/lib/seira/db.rb
@@ -265,9 +265,8 @@ module Seira
           ALTER DEFAULT PRIVILEGES IN SCHEMA "public" GRANT SELECT ON TABLES TO #{user_name};
         SQL
 
-      ips = Helpers.sql_ips(instance_name, context: context)
-      puts "Connecting to private ip for #{instance_name}: #{ips[:private]}"
-      execute_db_command(admin_commands, as_admin: true, private_ip: ips[:private])
+      puts "Connecting"
+      execute_db_command(admin_commands, as_admin: true)
       execute_db_command(database_commands)
     end
 
@@ -412,9 +411,10 @@ module Seira
       end
     end
 
-    def execute_db_command(sql_command, as_admin: false, interactive: false, print: true, private_ip: '127.0.0.1')
+    def execute_db_command(sql_command, as_admin: false, interactive: false, print: true)
       # TODO(josh): move pgbouncer naming logic here and in Create to a common location
       instance_name = primary_instance
+      private_ip = Helpers.sql_ips(instance_name, context: context)[:private]
       tier = instance_name.gsub("#{app}-", '')
       matching_pods = Helpers.fetch_pods(context: context, filters: { tier: tier })
       if matching_pods.empty?

--- a/lib/seira/db/create.rb
+++ b/lib/seira/db/create.rb
@@ -188,7 +188,7 @@ module Seira
       end
 
       def ips
-        Helpers.sql_ips(name, context: context)
+        @_ips ||= Helpers.sql_ips(name, context: context)
       end
 
       def write_pgbouncer_yaml

--- a/lib/seira/db/create.rb
+++ b/lib/seira/db/create.rb
@@ -188,13 +188,7 @@ module Seira
       end
 
       def ips
-        @_ips ||= begin
-          describe_command = "sql instances describe #{name}"
-          json = JSON.parse(gcloud(describe_command, context: context, format: :json))
-          private_ip = json['ipAddresses'].find { |address| address['type'] == 'PRIVATE' }['ipAddress']
-          public_ip = json['ipAddresses'].find { |address| address['type'] == 'PRIMARY' }['ipAddress']
-          { private: private_ip, public: public_ip }
-        end
+        Helpers.sql_ips(name, context: context)
       end
 
       def write_pgbouncer_yaml

--- a/lib/seira/db/create.rb
+++ b/lib/seira/db/create.rb
@@ -188,7 +188,7 @@ module Seira
       end
 
       def ips
-        @_ips ||= Helpers.sql_ips(name, context: context)
+        @ips ||= Helpers.sql_ips(name, context: context)
       end
 
       def write_pgbouncer_yaml

--- a/lib/seira/version.rb
+++ b/lib/seira/version.rb
@@ -1,3 +1,3 @@
 module Seira
-  VERSION = "0.5.3".freeze
+  VERSION = "0.5.5".freeze
 end


### PR DESCRIPTION
Fixing newly failing command `create_readonly_user` and adding support for `seira version` for easier troubleshooting.

⚠️ I need to clean the duplicated code for extracting private_ips.