### PR TITLE
kubectl version -c has been deprecated, use --client instead

### DIFF
--- a/lib/seira.rb
+++ b/lib/seira.rb
@@ -154,7 +154,7 @@ module Seira
         exit(1)
       end
 
-      unless system("kubectl version -c > /dev/null 2>&1")
+      unless system("kubectl version --client > /dev/null 2>&1")
         puts "Kubectl library not installed properly. Please install `kubectl` before using seira.".red
         exit(1)
       end


### PR DESCRIPTION
`kubectl version` does not accept `-c` anymore. 
```
› kubectl version -c                                                          
Error: unknown shorthand flag: 'c' in -c
```
See [relevant PR](https://gitlab.cncf.ci/kubernetes/kubernetes/commit/db7c8f633b4d53f356cdca7d257898df581c9aa8).

Let's use `kubectl version --client` instead.
```
› kubectl version --client                                                    
Client Version: version.Info{ ... }
```