### PR TITLE
add db configure action

### DIFF
--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -4,10 +4,12 @@ module Seira
 
     class << self
       def rails_env(context:)
-        if context[:cluster] == 'internal'
+        parsed_env = context[:settings].settings['seira']['clusters'][context[:cluster]]['environment']
+        parsed_env = context[:cluster] if parsed_env.nil?
+        if parsed_env == 'internal'
           'production'
         else
-          context[:cluster]
+          parsed_env
         end
       end
 

--- a/lib/seira/db.rb
+++ b/lib/seira/db.rb
@@ -94,7 +94,6 @@ module Seira
       puts SUMMARY
       puts "\n"
       puts <<~HELPTEXT
-        THIS IS THE LOCAL GEM
         analyze:                Display database performance information
         connect:                Open a psql command prompt via gcloud connect. You will be shown the password needed before the prompt opens.
         create:                 Create a new postgres instance in cloud sql. Supports creating replicas and other numerous flags.

--- a/lib/seira/db/create.rb
+++ b/lib/seira/db/create.rb
@@ -33,17 +33,7 @@ module Seira
 
         run_create_command
 
-        if replica_for.nil?
-          update_root_password
-          create_proxy_user
-        end
-
-        set_secrets
-
-        alter_proxy_user_roles if replica_for.nil?
-
-        puts "To use this database, use write-pgbouncer-yaml command and deploy the pgbouncer config file that was created and use the ENV that was set."
-        puts "To make this database the primary, promote it using the CLI and update the DATABASE_URL."
+        configure_created_db
       end
 
       def add(existing_instances)
@@ -71,7 +61,28 @@ module Seira
         puts "Credentials were saved in #{secrets_name}"
       end
 
+      def configure(instance_name, master_name)
+        @name = instance_name
+        @replica_for = master_name
+
+        configure_created_db
+
+        puts "To use this database, use write-pgbouncer-yaml command and deploy the pgbouncer config file that was created and use the ENV that was set."
+        puts "To make this database the primary, promote it using the CLI and update the DATABASE_URL."
+      end
+
       private
+
+      def configure_created_db
+        if replica_for.nil?
+          update_root_password
+          create_proxy_user
+        end
+
+        set_secrets
+
+        alter_proxy_user_roles if replica_for.nil?
+      end
 
       def run_create_command
         # The 'beta' is needed for HA and other beta features

--- a/lib/seira/db/create.rb
+++ b/lib/seira/db/create.rb
@@ -66,9 +66,6 @@ module Seira
         @replica_for = master_name
 
         configure_created_db
-
-        puts "To use this database, use write-pgbouncer-yaml command and deploy the pgbouncer config file that was created and use the ENV that was set."
-        puts "To make this database the primary, promote it using the CLI and update the DATABASE_URL."
       end
 
       private
@@ -82,6 +79,9 @@ module Seira
         set_secrets
 
         alter_proxy_user_roles if replica_for.nil?
+
+        puts "To use this database, use write-pgbouncer-yaml command and deploy the pgbouncer config file that was created and use the ENV that was set."
+        puts "To make this database the primary, promote it using the CLI and update the DATABASE_URL."
       end
 
       def run_create_command

--- a/lib/seira/version.rb
+++ b/lib/seira/version.rb
@@ -1,3 +1,3 @@
 module Seira
-  VERSION = "0.6.5".freeze
+  VERSION = "0.6.6".freeze
 end


### PR DESCRIPTION
Now that we're configuring our database instances via terraform we don't need to do it via `seira`. However, `seira` would take care of user and secret management, which we still do need.

This PR adds support for configuring an existing database instance.

We also noticed the helper that determines the rails environment uses the context cluster name which is not a safe assumption to make. 