### PR TITLE
Fix Jobs With No Web Tier

### DIFF
--- a/lib/seira/jobs.rb
+++ b/lib/seira/jobs.rb
@@ -104,7 +104,7 @@ module Seira
       existing_job_names = kubectl("get jobs --output=jsonpath={.items..metadata.name}", context: context, clean_output: true, return_output: true).split(" ").map(&:strip).map { |name| name.gsub(/^#{app}-run-/, '') }
       command = args.join(' ')
       unique_name = "#{app}-run-#{Random.unique_name(existing_job_names)}"
-      revision = gcp_app.ask_cluster_for_current_revision # TODO: Make more reliable, especially with no web tier
+      revision = ENV['REVISION'] || gcp_app.ask_cluster_for_current_revision
       replacement_hash = {
         'UNIQUE_NAME' => unique_name,
         'REVISION' => revision,

--- a/lib/seira/version.rb
+++ b/lib/seira/version.rb
@@ -1,3 +1,3 @@
 module Seira
-  VERSION = "0.7.1".freeze
+  VERSION = "0.7.2".freeze
 end


### PR DESCRIPTION
Not everything has an active deployment, so we should allow passing in a revision as an ENV in that case.