### PR TITLE
Introduce new app config files for removing guess work

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,15 @@ seira:
 
 This specification is read in and used to determine what `gcloud` context to use and what `kubectl` cluster to use when operating commands. For example, `seira internal` will connect to `org-internal` gcloud configuration and `gke_org-internal_us-central1-a_internal` kubectl cluster. For shorthand, `seira i` shorthand is specified as an alias.
 
+### Application Configuration Files
+
+Each app can also define configuration files. These files specify details that allow seira to execute commands with minimal user input, and declare aspects of the application. This file lives in the app folder with the name `.seira.app.yaml`. An example configuration file:
+
+```
+# The name of the sql instance as it shows in GCP Cloud SQL UI
+primary_sql_instance: app-database-name
+```
+
 ### Regions and Zones
 
 All clusters should have a `region` option specified. For zonal clusters (clusters that are NOT regional) should also specify their `zone`.

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -42,6 +42,8 @@ module Seira
       def get_seira_app_config(context:)
         yaml_file_path = "kubernetes/#{context[:cluster]}/#{context[:app]}/.seira.app.yaml"
         YAML.load_file(yaml_file_path)
+      rescue
+        fail "Failed to load the configuration file at #{yaml_file_path}. Please add configuration file and retry."
       end
 
       def get_current_replicas(deployment:, context:)

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -1,3 +1,5 @@
+require 'yaml'
+
 module Seira
   class Helpers
     include Seira::Commands
@@ -35,6 +37,11 @@ module Seira
 
       def get_secret(key:, context:)
         Secrets.new(app: context[:app], action: 'get', args: [], context: context).get(key)
+      end
+
+      def get_seira_app_config(context:)
+        yaml_file_path = "kubernetes/#{context[:cluster]}/#{context[:app]}/.seira.app.yaml"
+        YAML.load_file(yaml_file_path)
       end
 
       def get_current_replicas(deployment:, context:)

--- a/lib/seira/version.rb
+++ b/lib/seira/version.rb
@@ -1,3 +1,3 @@
 module Seira
-  VERSION = "0.7.3".freeze
+  VERSION = "0.7.4".freeze
 end


### PR DESCRIPTION
Currently we fetch a secret, parse out a key's value, and then use the host of the URI to calculate the primary database name.

That has two issues:
* Guess work
* Requires access

This introduces a file that will be in each app's folder to define some of these things to remove guess work and access requirements.