### PR TITLE
Support environment variable for config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ The only exception is commands on the cluster itself, which does not take an `<a
 
 ### Configuration File
 
-A configuration file is expected at `.seira.yml` relative path. Below is an example file.
+By default, a configuration file is expected at `.seira.yml` relative path. Alternatively, the path can be specified using the environment variable `SEIRA_CONFIG_PATH`, ex. `export SEIRA_CONFIG_PATH=/path/to/.seira.yml`.
+
+Below is an example file.
 
 ```
 seira:

--- a/lib/seira/settings.rb
+++ b/lib/seira/settings.rb
@@ -3,7 +3,7 @@ require 'yaml'
 
 module Seira
   class Settings
-    DEFAULT_CONFIG_PATH = '.seira.yml'.freeze
+    DEFAULT_CONFIG_PATH = ENV['SEIRA_CONFIG_PATH'] || '.seira.yml'.freeze
 
     attr_reader :config_path
 

--- a/lib/seira/version.rb
+++ b/lib/seira/version.rb
@@ -1,3 +1,3 @@
 module Seira
-  VERSION = "0.7.4".freeze
+  VERSION = "0.7.5".freeze
 end


### PR DESCRIPTION
This allows us to set the config file path as an environment variable, letting the user run `seira` from from anywhere.