### PR TITLE
Remove unused 'run' command on pods.

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Pods can be listed and also exec'd into.
 
 `seira staging app-name pods list`
 
-`seira staging app-name pods run`
+`seira staging app-name pods connect --pod=<POD-NAME>`
 
 ## Development
 

--- a/lib/seira/pods.rb
+++ b/lib/seira/pods.rb
@@ -31,8 +31,6 @@ module Seira
         run_top
       when 'connect'
         run_connect
-      when 'run'
-        run_run
       else
         fail "Unknown command encountered"
       end


### PR DESCRIPTION
Thanks for providing this! This library has made my life much easier today. 😁 

I noticed the README suggested `pod run` as a valid command, but internally the required `run_run` command wasn't implemented. Maybe this is some loose copy-paste artifact from `lib/seira/jobs.rb`? ✂️ 

This change trims the broken command off the `pods` module & updates the README to accurately demonstrate connecting to a running pod.

Please let me know if I've misunderstood the intent here! 🕵️ I'd love to understand things better if there's something I've missed.