### PR TITLE
Clean up test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,6 @@ language: ruby
 notifications:
   email: false
 rvm:
-  - 2.5.3
+  - 2.6.3
+  - 2.7.2
 before_install: gem install bundler

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Seira
 
 [![Gem Version](https://badge.fury.io/rb/seira.svg)](https://badge.fury.io/rb/seira)
-[![Build Status](https://travis-ci.org/joinhandshake/seira.svg?branch=master)](https://travis-ci.org/joinhandshake/seira)
+[![Build Status](https://travis-ci.com/joinhandshake/seira.svg?branch=main)](https://travis-ci.com/github/joinhandshake/seira)
 
 An opinionated library for building applications on Kubernetes.
 


### PR DESCRIPTION
The test suite needed to migrate from travis-ci.org (deprecated / turned off) to travis-ci.com. I also upped the test suite ruby version.